### PR TITLE
Make the register page responsive #12

### DIFF
--- a/frontend/src/pages/Auth/Register.jsx
+++ b/frontend/src/pages/Auth/Register.jsx
@@ -61,7 +61,7 @@ const Register = () => {
             <input
               type="text"
               id="name"
-              className=" w-1/4 md:w-1/2 lg:w-full mt-1 p-2 border rounded "
+              className="w-1/4 md:w-1/2 lg:w-full mt-1 p-2 border rounded "
               placeholder="Enter name"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
@@ -70,7 +70,7 @@ const Register = () => {
           <div className="my-[2rem]">
             <label
               htmlFor="email"
-              className="w-1/4 md:w-1/2 lg:w-full block text-sm font-medium text-white"
+              className="block text-sm font-medium text-white"
             >
               Email
             </label>

--- a/frontend/src/pages/Auth/Register.jsx
+++ b/frontend/src/pages/Auth/Register.jsx
@@ -61,7 +61,7 @@ const Register = () => {
             <input
               type="text"
               id="name"
-              className="mt-1 p-2 border rounded w-full"
+              className=" w-1/4 md:w-1/2 lg:w-full mt-1 p-2 border rounded "
               placeholder="Enter name"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
@@ -70,14 +70,14 @@ const Register = () => {
           <div className="my-[2rem]">
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-white"
+              className="w-1/4 md:w-1/2 lg:w-full block text-sm font-medium text-white"
             >
               Email
             </label>
             <input
               type="email"
               id="email"
-              className="mt-1 p-2 border rounded w-full"
+              className="w-1/4 md:w-1/2 lg:w-full mt-1 p-2 border rounded"
               placeholder="Enter email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -93,7 +93,7 @@ const Register = () => {
             <input
               type="password"
               id="password"
-              className="mt-1 p-2 border rounded w-full"
+              className="w-1/4 md:w-1/2 lg:w-full mt-1 p-2 border rounded"
               placeholder="Enter password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -109,7 +109,7 @@ const Register = () => {
             <input
               type="password"
               id="confirmPassword"
-              className="mt-1 p-2 border rounded w-full"
+              className="w-1/4 md:w-1/2 lg:w-full mt-1 p-2 border rounded"
               placeholder="Confirm Password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}


### PR DESCRIPTION
Issue - #12 
Added responsiveness to the registration page by decreasing the width of the input box after the medium and large endpoints. Set w-1/4 for screen sizes below medium endpoint. I am open for any changes and feedbacks. 

![Screenshot 2025-01-02 110503](https://github.com/user-attachments/assets/96f4bcc5-1c7b-4d93-afdd-b1f97899319b)
