### PR TITLE
[🐛Bug Fix]: Fixed "Anchor Tag cannot be child of Anchor Tag Console Error"

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -53,29 +53,20 @@ const Footer = () => {
           <h4 className="text-xl font-semibold mb-4">Quick Links</h4>
           <ul className="space-y-2">
             <li>
-              <a href="/products" className="text-gray-300 hover:text-white">
-                <Link to="/shop">Shop All Products</Link>
-                
-              </a>
+                {/* change "/shop" to "/products" when you have the products page */}
+                <Link to="/shop" className="text-gray-300 hover:text-white">Shop All Products</Link>
             </li>
             <li>
-              <a href="/offers" className="text-gray-300 hover:text-white">
-                <Link to="/shop">Offers</Link>
-              
-                
-              </a>
+                {/* change "/offers" to "/offers" when you have the offers page */}
+                <Link to="/shop" className="text-gray-300 hover:text-white">Offers</Link>
             </li>
             <li>
-              <a href="/blog" className="text-gray-300 hover:text-white">
-              <Link to="/shop"> Blog</Link>
-               
-              </a>
+              {/* change "/shop" to "/blog" when you have the blog page */}
+              <Link to="/shop" className="text-gray-300 hover:text-white"> Blog</Link>
             </li>
             <li>
-              <a href="/faq" className="text-gray-300 hover:text-white">
-              <Link to="/shop">FAQs</Link>
-                
-              </a>
+              {/* change "/shop" to "/faq" when you have the faq page */}
+              <Link to="/shop" className="text-gray-300 hover:text-white">FAQs</Link>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
# [🐛Bug Fix]: Fixed "Anchor Tag cannot be child of Anchor Tag Console Error"

### 🔭 Scope: [🖥️ Frontend]
### ⭕ Issue: Close #68 

## Bug Fix Report
A summary about the bug:
- The bug was about a console error saying anchor tag cannot be a child of another anchor tag
- This bug originated due to an anchor tag wrapping a Link tag in the Footer component, Quick Links section
- As Link tags from "react-router-dom" are by primitive(default) an anchor tag wrappers
- This resulted in DOM complaining that an anchor tag is wrapping another anchor tag causing discrepancy

A summary of changes made:
- Anchor tags wrapping Link tags were removed
- Tailwind CSS applied on Anchor tags was moved to Link tags
- Currently all of them redirect to "/shop" page, but comments are added with their future paths to be modified once respective pages become available or are added

## Contributor Note
- Thank you for assigning me the issue promptly, I am doing this PR closing the above forementioned issue.
- I am part of SWOC and have enrolled this project, I kindly request the mentor to take a note of the same. 

Thank you