### PR TITLE
Remove the button inside the quantity box

### DIFF
--- a/frontend/src/components/Cart.jsx
+++ b/frontend/src/components/Cart.jsx
@@ -44,7 +44,11 @@ function Cart() {
                     type="number"
                     value={item.quantity}
                     onChange={(e) => updateQuantity(item.id, parseInt(e.target.value))}
-                    className="w-16 text-center"
+                    className="w-16 text-center no-spin"
+                    style={{
+                      WebkitAppearance: "none",
+                      MozAppearance: "textfield",
+                    }}
                   />
                   <Button
                     variant="outline"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,3 +17,12 @@ textarea {
   *::-webkit-scrollbar {
     display: none; /* Hide scrollbar for Webkit browsers */
   }
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type="number"] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## Description
I realized that <input type="number"> automatically adds the buttons. So I decided to fix it using CSS in index.css file. 
I used the following additions:
- "-webkit-inner-spin-button" and "-webkit-outer-spin-button" are for Chrome and Safari browsers.
- "-moz-appearance: textfield" is for Firefox browser.
- The style property applies these styles directly. 


## Related Issue
#117 has been resolved.

## Type of change
<!--- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
- [x] Test A (eg: Manual Testing)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] These are not breaking changes

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/baef678f-843d-4a0c-afbe-c20de37da611)
