### PR TITLE
Fix null value in the quantity box

### DIFF
--- a/frontend/src/components/Cart.jsx
+++ b/frontend/src/components/Cart.jsx
@@ -43,7 +43,14 @@ function Cart() {
                   <Input
                     type="number"
                     value={item.quantity}
-                    onChange={(e) => updateQuantity(item.id, parseInt(e.target.value))}
+                    onChange={(e) => {
+                      const value = parseInt(e.target.value)
+                      if (isNaN(value) || value <= 0){
+                        updateQuantity(item.id, 1) //Reset to 1 in invalid case
+                      } else{
+                        updateQuantity(item.id, value) //Update with a valid value
+                      }
+                    }}
                     className="w-16 text-center no-spin"
                     style={{
                       WebkitAppearance: "none",


### PR DESCRIPTION
## Description
The user can enter a null value in the quantity box on the Cart page. I changed it in a way that the user can not enter null value in the quantity box. If the user wants to enter a null value, the field will be reset to 1. 

## Related Issue
#127 has been resolved. 

## Type of change
<!--- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
- [ ] Test A (eg: Manual Testing)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] These are not breaking changes

## Screenshots (if appropriate):