### PR TITLE
fix(auth): sign up works with an empty form

### DIFF
--- a/frontend/src/pages/Auth/Register.jsx
+++ b/frontend/src/pages/Auth/Register.jsx
@@ -39,6 +39,15 @@ const Register = () => {
 
   const submitHandler = async (e) => {
     e.preventDefault();
+    if (
+      username === "" ||
+      email === "" ||
+      password === "" ||
+      confirmPassword == ""
+    ) {
+      toast.error("Please fill all fields");
+      return;
+    }
     if (password !== confirmPassword) {
       toast.error("Password does not match");
     } else {


### PR DESCRIPTION
## Description
Added validation to ensure that the sign-up form cannot be submitted with empty fields. If any of the required fields (username, email, password, or confirm password) are empty, a toast error message will be displayed, and the form submission will be halted.

## Related Issue
Fixes #115
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Test A (Manual Testing)
  - Tested by attempting to submit the form with empty fields and verifying that the toast error message appears and the form is not submitted.
  - Tested by filling in all fields and verifying that the form submits successfully.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] These are not breaking changes

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/ae3ed0c8-8f8f-4250-a87e-85d3e79e8aae

