### PR TITLE
Fix Login form can be submitted with blank fields

### DIFF
--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -33,6 +33,10 @@ const Login = () => {
 
   const submitHandler = async (e) => {
     e.preventDefault();
+    if (!email.trim() || !password.trim()){
+      toast.error("Please fill all the fields")
+      return;
+    }
 
     try {
       const res = await login({ email, password }).unwrap();


### PR DESCRIPTION
## Description
When the user leaves the fields blank and presses the sign-in button on the login page, the form is sent to the server. 
I fixed it. Now if the user leaves the fields blank and presses the sign-in button, they get an appropriate error and the form will not be sent to the server.

## Related Issue
#135 has been resolved. 

## Type of change
<!--- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
- [ ] Test A (eg: Manual Testing)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] These are not breaking changes

## Screenshots (if appropriate):