### PR TITLE
Favorite Product Bug Fixed

### DIFF
--- a/frontend/src/pages/Products/HeartIcon.jsx
+++ b/frontend/src/pages/Products/HeartIcon.jsx
@@ -11,7 +11,7 @@ const HeartIcon = ({ product ,className}) => {
     const favorites = useSelector((state) => state.favorites.favorites);
     const userInfo = useSelector((state) => state.auth?.userInfo);
 
-    const isFavorite = favorites?.some((p) => p.id === product.id) || false;
+    const isFavorite = favorites?.some((p) => p._id === product._id) || false;
 
     const toggleFavorite = (e) => {
         e.stopPropagation();

--- a/frontend/src/pages/Shop/Shop.jsx
+++ b/frontend/src/pages/Shop/Shop.jsx
@@ -359,7 +359,7 @@ export default function ShopPage() {
           {products.length > 0 ? (
             products.map((product) => (
               <div
-                key={product.id}
+                key={product._id}
                 className="bg-pink-500 shadow-md rounded-lg p-4 transform hover:scale-105 hover:shadow-lg transition duration-300 relative"
               >
                 <h2 className="text-xl font-bold text-white mb-2">{product.name}</h2>

--- a/frontend/src/pages/redux/features/favorites/favoriteSlice.js
+++ b/frontend/src/pages/redux/features/favorites/favoriteSlice.js
@@ -20,7 +20,7 @@ const favoriteSlice = createSlice({
     reducers: {
         addToFavorites: (state, action) => {
             const newProduct = action.payload;
-            const exists = state.favorites.some(item => item.id === newProduct.id);
+            const exists = state.favorites.some(item => item._id === newProduct._id);              
 
             if (!exists) {
                 const updatedFavorites = [...state.favorites, newProduct];
@@ -35,9 +35,7 @@ const favoriteSlice = createSlice({
         },
         removeFromFavorites: (state, action) => {
             const productToRemove = action.payload;
-            const updatedFavorites = state.favorites.filter(
-                item => item.id !== productToRemove.id
-            );
+            const updatedFavorites = state.favorites.filter(item => (item._id !== productToRemove._id));
 
             state.favorites = updatedFavorites;
 


### PR DESCRIPTION
## Description  
This PR fixes the issue where clicking the favorite icon affects all products instead of the selected one. The functionality has been updated to ensure that adding or removing a product from favorites applies only to the specific product clicked by the user.  

## Related Issue  
Fixes #156 

## Type of change  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  

## How Has This Been Tested?  
- [x] Manual Testing (Verified product selection and favorite functionality behavior)  
- [ ] Unit Tests  
- [ ] Integration Tests  
- [ ] N/A (No Tests)  

## Checklist:  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] Any dependent changes have been merged and published in downstream modules  
- [x] These are not breaking changes  

**Page/Feature Location:**  
`/shop`

Hey @Anwishta, kindly review and merge this PR. Looking forward to your feedback! 😊