### PR TITLE
Fix scroll issue on Terms and Conditions page

### DIFF
--- a/frontend/src/pages/Footer/TermsAndConditions.jsx
+++ b/frontend/src/pages/Footer/TermsAndConditions.jsx
@@ -1,6 +1,10 @@
-import React from "react";
+import React, {useEffect} from "react";
 
 export const TermsAndConditions = () => {
+    useEffect(() => {
+        window.scrollTo(0, 0)
+    }, []);
+    
     const termsData = {
         title: "Terms and Conditions",
         lastUpdated: "January 2025",


### PR DESCRIPTION
## Description
When the user opens Terms and Conditions page, the page opens at the beginning. 

## Related Issue
#247 has been resolved. 

## Type of change
<!--- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
- [x] Test A (eg: Manual Testing)
- [ ] Test B (eg: Unit Tests)
- [ ] Test C (eg: Integration Tests)
- [ ] N A (eg: No Tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] These are not breaking changes

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/61db5469-e552-4a52-a7f3-809e6a4ad47a


## Let us know if you are part of SWOC or IWOC

- [ ] SWOC
- [ ] IWOC
- [ ] Neither