### PR TITLE
Enable Dot Scrolling Navigation in Dark Mode for Banner Carousel

### DIFF
--- a/frontend/src/components/carousel.jsx
+++ b/frontend/src/components/carousel.jsx
@@ -1,24 +1,59 @@
-import React from "react";
+import React, { useState } from "react";
 import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
 const Carousel = ({ children }) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
   const settings = {
-    dots: true, // Show navigation dots
-    infinite: true, // Enable infinite looping
-    speed: 500, // Transition speed in ms
-    slidesToShow: 1, // Number of slides to show at once
-    slidesToScroll: 1, // Number of slides to scroll at a time
-    autoplay: true, // Auto-scroll enabled
-    autoplaySpeed: 3000, // Auto-scroll speed in ms
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    autoplay: true,
+    autoplaySpeed: 3000,
+
+    beforeChange: (oldIndex, newIndex) => setActiveIndex(newIndex),
+
+    appendDots: dots => (
+      <div
+        style={{
+          position: "absolute",
+          bottom: "15px",
+          width: "100%",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          listStyle: "none",
+          background: "rgba(0, 0, 0, 0.5)", // Dark background for better visibility
+          padding: "8px",
+          borderRadius: "12px",
+        }}
+      >
+        <ul style={{ display: "flex", gap: "10px", padding: 0, margin: 0 }}>{dots}</ul>
+      </div>
+    ),
+
+    customPaging: i => (
+      <div
+        style={{
+          width: "12px", // Fixed size for all dots
+          height: "12px",
+          borderRadius: "50%",
+          backgroundColor: i === activeIndex ? "#ffffff" : "rgba(255, 255, 255, 0.4)", // Darker when active
+          border: "2px solid white",
+          boxShadow: "0px 0px 5px rgba(0,0,0,0.6)", // Adds better visibility
+          transition: "background-color 0.3s ease-in-out",
+        }}
+      />
+    ),
   };
 
   return (
-    <div style={{ margin: "0 auto" }} className="md:w-[100%]">
-      <Slider {...settings}>
-        {children}
-      </Slider>
+    <div style={{ margin: "0 auto", position: "relative" }} className="md:w-[100%]">
+      <Slider {...settings}>{children}</Slider>
     </div>
   );
 };

--- a/frontend/src/pages/Offer/banners.jsx
+++ b/frontend/src/pages/Offer/banners.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Carousel from "../../components/carousel"; // Ensure Carousel is compatible with React
+import Carousel from "../../components/carousel";
 
 export function Banners() {
     const banners = [
@@ -28,12 +28,12 @@ export function Banners() {
           "link": "https://www.flipkart.com/footwear-sale",
           "imageUrl": "/images/footwear-banner.jpg"
         }
-      ]
+      ];
       
     return (
         <Carousel>
-            {banners.map((item,index)=>(
-                <img src={item.imageUrl} alt="" className="md:w-[30rem] object-fill md:h-[30rem]" />
+            {banners.map((item, index) => (
+                <img key={index} src={item.imageUrl} alt={item.name} className="md:w-[30rem] object-fill md:h-[30rem]" />
             ))}
         </Carousel>
     );


### PR DESCRIPTION
## Description
This PR enhances the banner carousel by improving the visibility of dot navigation indicators in dark mode. Previously, the dots were not easily visible on darker backgrounds, affecting navigation clarity.

## Related Issue
<!--- Please link to the issue here eg: Fixes #123 -->
Fixes #277 

## Type of change
<!--- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
- [x] Test A (eg: Manual Testing)
- [x] Test B (eg: Unit Tests)
- [x] Test C (eg: Integration Tests)
- [ ] N A (eg: No Tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] These are not breaking changes

## Screenshots (if appropriate):
`Before`
![Screenshot 2025-02-24 200639](https://github.com/user-attachments/assets/5326d941-6d60-4352-8d0e-3a50c6bcf842)
`After`
![Screenshot 2025-02-24 200700](https://github.com/user-attachments/assets/5a26bc6f-e17d-4518-9d28-721182a1c424)


## Let us know if you are part of SWOC or IWOC

- [x] SWOC
- [ ] IWOC
- [ ] Neither